### PR TITLE
Fire RESIZE_EVENT in addition to GRAPHIC_EVENT on graphic prop update

### DIFF
--- a/src/main/java/eu/hansolo/tilesfx/Tile.java
+++ b/src/main/java/eu/hansolo/tilesfx/Tile.java
@@ -1380,7 +1380,10 @@ public class Tile extends Control {
     public ObjectProperty<Node> graphicProperty() {
         if (null == graphic) {
             graphic = new ObjectPropertyBase<Node>() {
-                @Override protected void invalidated() { fireTileEvent(GRAPHIC_EVENT); }
+                @Override protected void invalidated() {
+                	fireTileEvent(GRAPHIC_EVENT);
+                	fireTileEvent(RESIZE_EVENT);
+                }
                 @Override public Object getBean() { return Tile.this; }
                 @Override public String getName() { return "graphic"; }
             };


### PR DESCRIPTION
When a graphic is update via property, the new node was previously not
receiving the correct size when updated. An illustrating scenario is this:
 - Create two SVGPath instances which we will flip between based on a
   "when" binding. The first image shown works correctly, but when
   changing to the second image its size is not updated. For example,
   in the case where -since the last time it was shown- the window has
   been resized.