### PR TITLE
Bug/graphic scaling

### DIFF
--- a/src/main/java/eu/hansolo/tilesfx/Tile.java
+++ b/src/main/java/eu/hansolo/tilesfx/Tile.java
@@ -1380,7 +1380,10 @@ public class Tile extends Control {
     public ObjectProperty<Node> graphicProperty() {
         if (null == graphic) {
             graphic = new ObjectPropertyBase<Node>() {
-                @Override protected void invalidated() { fireTileEvent(GRAPHIC_EVENT); }
+                @Override protected void invalidated() {
+                	fireTileEvent(GRAPHIC_EVENT);
+                	fireTileEvent(RESIZE_EVENT);
+                }
                 @Override public Object getBean() { return Tile.this; }
                 @Override public String getName() { return "graphic"; }
             };

--- a/src/main/java/eu/hansolo/tilesfx/skins/CustomTileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/CustomTileSkin.java
@@ -148,8 +148,8 @@ public class CustomTileSkin extends TileSkin {
 		                    }
 		                    else scale = containerHeight / height;
 
-		                    graphic.setScaleX( scale );
-		                    graphic.setScaleY( scale );
+		                    graphic.setScaleX(scale);
+		                    graphic.setScaleY(scale);
 	                    }
                     } else if (tile.getGraphic() instanceof ImageView) {
                         ((ImageView) graphic).setFitWidth(containerWidth);

--- a/src/main/java/eu/hansolo/tilesfx/skins/CustomTileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/CustomTileSkin.java
@@ -141,21 +141,16 @@ public class CustomTileSkin extends TileSkin {
                         double width   = graphic.getBoundsInLocal().getWidth();
                         double height  = graphic.getBoundsInLocal().getHeight();
 
-                        if (width > containerWidth || height > containerHeight) {
-                            double aspect = height / width;
-                            if (aspect * width > height) {
-                                width = 1 / (aspect / height);
-                                graphic.setScaleX(containerWidth / width);
-                                graphic.setScaleY(containerWidth / width);
-                            } else if (1 / (aspect / height) > width) {
-                                height = aspect * width;
-                                graphic.setScaleX(containerHeight / height);
-                                graphic.setScaleY(containerHeight / height);
-                            } else {
-                                graphic.setScaleX(containerHeight / height);
-                                graphic.setScaleY(containerHeight / height);
-                            }
-                        }
+	                    if (width > containerWidth || height > containerHeight) {
+		                    double scale;
+		                    if (width - containerWidth > height - containerHeight) {
+			                    scale = containerWidth / width;
+		                    }
+		                    else scale = containerHeight / height;
+
+		                    graphic.setScaleX( scale );
+		                    graphic.setScaleY( scale );
+	                    }
                     } else if (tile.getGraphic() instanceof ImageView) {
                         ((ImageView) graphic).setFitWidth(containerWidth);
                         ((ImageView) graphic).setFitHeight(containerHeight);

--- a/src/main/java/eu/hansolo/tilesfx/skins/CustomTileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/CustomTileSkin.java
@@ -145,8 +145,7 @@ public class CustomTileSkin extends TileSkin {
 		                    double scale;
 		                    if (width - containerWidth > height - containerHeight) {
 			                    scale = containerWidth / width;
-		                    }
-		                    else scale = containerHeight / height;
+		                    } else scale = containerHeight / height;
 
 		                    graphic.setScaleX(scale);
 		                    graphic.setScaleY(scale);


### PR DESCRIPTION
Adjust graphic scaling calculation to avoid clipping in certain scenarios. For example:
Before:
![before](https://cloud.githubusercontent.com/assets/1891321/26015362/526bed2c-3726-11e7-9256-cd148f978e34.png)
After:
![after](https://cloud.githubusercontent.com/assets/1891321/26015366/54a2f770-3726-11e7-8f81-e12d0b699266.png)

I'm not totally certain this is what you want to do with the scaling, so please sanity check. It makes sense with images, which I assume is the main use (and mine right now) case since the property is named "graphic". However, since the "graphic" property can really contain a `Node`, it might make more sense to simply make it file the tile and then the Node can decide what to do (or make a separate TileSkin type or additional property) to allow control.