### PR TITLE
fixed MemoryLeak in the WorldMap and a small improvement for the demo-page

### DIFF
--- a/src/main/java/eu/hansolo/tilesfx/Demo.java
+++ b/src/main/java/eu/hansolo/tilesfx/Demo.java
@@ -74,7 +74,7 @@ public class Demo extends Application {
     private static final    Random RND = new Random();
     private static final    double TILE_WIDTH  = 150;
     private static final    double TILE_HEIGHT = 150;
-    private static          int    noOfNodes = 0;
+    private                 int    noOfNodes = 0;
 
     private BarChartItem    barChartItem1;
     private BarChartItem    barChartItem2;
@@ -799,12 +799,18 @@ public class Demo extends Application {
     }
 
     @Override public void stop() {
+
+        // useful for jpro
+        timer.stop();
+        clockTile.setRunning(false);
+        timerControlTile.setRunning(false);
+
         System.exit(0);
     }
 
 
     // ******************** Misc **********************************************
-    private static void calcNoOfNodes(Node node) {
+    private void calcNoOfNodes(Node node) {
         if (node instanceof Parent) {
             if (((Parent) node).getChildrenUnmodifiable().size() != 0) {
                 ObservableList<Node> tempChildren = ((Parent) node).getChildrenUnmodifiable();

--- a/src/main/java/eu/hansolo/tilesfx/tools/Helper.java
+++ b/src/main/java/eu/hansolo/tilesfx/tools/Helper.java
@@ -62,9 +62,7 @@ public class Helper {
     private static final String                         HIRES_COUNTRY_PROPERTIES = "eu/hansolo/tilesfx/highres.properties";
     private static final String                         LORES_COUNTRY_PROPERTIES = "eu/hansolo/tilesfx/lowres.properties";
     private static       Properties                     hiresCountryProperties;
-    private static       Map<String, List<CountryPath>> hiresCountryPaths;
     private static       Properties                     loresCountryProperties;
-    private static       Map<String, List<CountryPath>> loresCountryPaths;
 
     public static final double   MAP_WIDTH         = 1009.1149817705154 - 1.154000163078308;
     public static final double   MAP_HEIGHT        = 665.2420043945312;
@@ -474,28 +472,25 @@ public class Helper {
 
     public static final Map<String, List<CountryPath>> getHiresCountryPaths() {
         if (null == hiresCountryProperties) { hiresCountryProperties = readProperties(HIRES_COUNTRY_PROPERTIES); }
-        if (null == hiresCountryPaths) {
-            hiresCountryPaths = new ConcurrentHashMap<>();
-            hiresCountryProperties.forEach((key, value) -> {
-                String            name     = key.toString();
-                List<CountryPath> pathList = new ArrayList<>();
-                for (String path : value.toString().split(";")) { pathList.add(new CountryPath(name, path)); }
-                hiresCountryPaths.put(name, pathList);
-            });
-        }
+
+        Map<String, List<CountryPath>> hiresCountryPaths = new ConcurrentHashMap<>();
+        hiresCountryProperties.forEach((key, value) -> {
+            String            name     = key.toString();
+            List<CountryPath> pathList = new ArrayList<>();
+            for (String path : value.toString().split(";")) { pathList.add(new CountryPath(name, path)); }
+            hiresCountryPaths.put(name, pathList);
+        });
         return hiresCountryPaths;
     }
     public static final Map<String, List<CountryPath>> getLoresCountryPaths() {
         if (null == loresCountryProperties) { loresCountryProperties = readProperties(LORES_COUNTRY_PROPERTIES); }
-        if (null == loresCountryPaths) {
-            loresCountryPaths = new ConcurrentHashMap<>();
-            loresCountryProperties.forEach((key, value) -> {
-                String            name     = key.toString();
-                List<CountryPath> pathList = new ArrayList<>();
-                for (String path : value.toString().split(";")) { pathList.add(new CountryPath(name, path)); }
-                loresCountryPaths.put(name, pathList);
-            });
-        }
+        Map<String, List<CountryPath>> loresCountryPaths = new ConcurrentHashMap<>();
+        loresCountryProperties.forEach((key, value) -> {
+           String            name     = key.toString();
+           List<CountryPath> pathList = new ArrayList<>();
+           for (String path : value.toString().split(";")) { pathList.add(new CountryPath(name, path)); }
+           loresCountryPaths.put(name, pathList);
+        });
         return loresCountryPaths;
     }
     private static final Properties readProperties(final String FILE_NAME) {


### PR DESCRIPTION
fixed MemoryLeak in the WorldMap

We can't cache the SVGPaths for the different countries, between multiples WorldMapTiles.

There are two problems:
 - we add ClickListeners to the static SVGPath which has a reference to the Scene which leads to an memory-leak
 - We can't add single SVGPath to multiple Scenes. This has the effects, that the countries are removed, when another WorldMapTile is instantiated