### PR TITLE
fixed the method adjustTextSize

### DIFF
--- a/src/main/java/eu/hansolo/tilesfx/tools/Helper.java
+++ b/src/main/java/eu/hansolo/tilesfx/tools/Helper.java
@@ -251,15 +251,16 @@ public class Helper {
     public static final void adjustTextSize(final Text TEXT, final double MAX_WIDTH, final double FONT_SIZE) {
         final String FONT_NAME          = TEXT.getFont().getName();
         double       adjustableFontSize = FONT_SIZE;
-        while (TEXT.getLayoutBounds().getWidth() > MAX_WIDTH && adjustableFontSize > 0) {
-            adjustableFontSize -= 0.005;
+
+        while (TEXT.getBoundsInLocal().getWidth() > MAX_WIDTH && adjustableFontSize > 0) {
+            adjustableFontSize -= 0.05;
             TEXT.setFont(new Font(FONT_NAME, adjustableFontSize));
         }
     }
     public static final void adjustTextSize(final Label TEXT, final double MAX_WIDTH, double fontSize) {
         final String FONT_NAME = TEXT.getFont().getName();
-        while (TEXT.getLayoutBounds().getWidth() > MAX_WIDTH && fontSize > 0) {
-            fontSize -= 0.005;
+        while (TEXT.getBoundsInLocal().getWidth() > MAX_WIDTH && fontSize > 0) {
+            fontSize -= 0.05;
             TEXT.setFont(new Font(FONT_NAME, fontSize));
         }
     }


### PR DESCRIPTION
fixed the method adjustTextSize
 - The method getLayoutBounds() didn't get updated. Now getBoundsInLocal is used.
 - Now, the step is much bigger, to make worst-case scenarios less painful

 previously:
 when resizing the stage to a very small size, some texts where adjusted to the fontsize 0, which required up to 15000 steps.
 With multiple Nodes, it created up too 100.000 Fonts. ;)
 This led to some problems related to jpro on mobile-browsers.