### PR TITLE
fix a bug where the matrix tile colors are not correctly set during initial ui construction.

### DIFF
--- a/src/main/java/eu/hansolo/tilesfx/skins/MatrixTileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/MatrixTileSkin.java
@@ -21,6 +21,7 @@ import eu.hansolo.tilesfx.chart.ChartData;
 import eu.hansolo.tilesfx.chart.PixelMatrix;
 import eu.hansolo.tilesfx.chart.PixelMatrix.PixelShape;
 import eu.hansolo.tilesfx.chart.PixelMatrixBuilder;
+import eu.hansolo.tilesfx.events.ChartDataEvent;
 import eu.hansolo.tilesfx.events.ChartDataEventListener;
 import eu.hansolo.tilesfx.events.PixelMatrixEventListener;
 import eu.hansolo.tilesfx.events.TileEvent;
@@ -243,12 +244,12 @@ public class MatrixTileSkin extends TileSkin {
         text.setText(tile.getText());
 
         resizeStaticText();
-        matrix.drawMatrix();
 
         titleText.setFill(tile.getTitleColor());
         text.setFill(tile.getTextColor());
 
         matrix.setPixelOnColor(tile.getBarColor());
         matrix.setPixelOffColor(Helper.isDark(tile.getBackgroundColor()) ? tile.getBackgroundColor().brighter() : tile.getBackgroundColor().darker());
+        updateMatrixWithChartData();
     }
 }


### PR DESCRIPTION
How to reproduce the bug:
* disable the timer startup in the Demo ```// timer.start();```
* start the demo
* here you can see that the MatrixTileSkin does not draw its matrix correctly

The following patch solve this bug.