### PR TITLE
Fix BarChartItemName not updating

### DIFF
--- a/src/main/java/eu/hansolo/tilesfx/skins/BarChartItem.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/BarChartItem.java
@@ -159,7 +159,10 @@ public class BarChartItem extends Region implements Comparable<BarChartItem>{
     @Override public ObservableList<Node> getChildren() { return super.getChildren(); }
 
     public String getName() { return chartData.getName(); }
-    public void setName(final String NAME) { chartData.setName(NAME); }
+    public void setName(final String NAME) { 
+        chartData.setName(NAME); 
+        nameText.setText(NAME);
+    }
 
     public double getValue() { return chartData.getValue(); }
     public void setValue(final double VALUE) { chartData.setValue(VALUE); }


### PR DESCRIPTION
Fixing bug BarChartItemName not updating when setName() is called.