### PR TITLE
Table skin, and a few added properties

### DIFF
--- a/src/main/java/eu/hansolo/tilesfx/Demo.java
+++ b/src/main/java/eu/hansolo/tilesfx/Demo.java
@@ -152,6 +152,7 @@ public class Demo extends Application {
     private Tile            imageTile;
     private Tile            timelineTile;
     private Tile            imageCounterTile;
+    private Tile            ledTile;
 
 
     private long            lastTimerCall;
@@ -828,6 +829,14 @@ public class Demo extends Application {
                                       .imageMask(ImageMask.ROUND)
                                       .build();
 
+        ledTile = TileBuilder.create()
+                .skinType(SkinType.LED)
+                .prefSize(TILE_WIDTH, TILE_HEIGHT)
+                .title("LED Tile")
+                .activeColor(new Color(0, 1, 0.2, 1))
+                .text("Whatever text")
+                .build();
+
         lastTimerCall = System.nanoTime();
         timer = new AnimationTimer() {
             @Override public void handle(long now) {
@@ -889,6 +898,8 @@ public class Demo extends Application {
 
                     imageCounterTile.increaseValue(1);
 
+                    ledTile.setValue(Math.round(RND.nextDouble()));
+
                     lastTimerCall = now;
                 }
             }
@@ -910,7 +921,7 @@ public class Demo extends Application {
                                              smoothAreaChartTile, countryTile, ephemerisTile, characterTile,
                                              flipTile, switchSliderTile, dateTile, calendarTile, sunburstTile,
                                              matrixTile, radialPercentageTile, statusTile, barGaugeTile, imageTile,
-                                             timelineTile, imageCounterTile);//, weatherTile);
+                                             timelineTile, imageCounterTile, ledTile);//, weatherTile);
 
         pane.setHgap(5);
         pane.setVgap(5);

--- a/src/main/java/eu/hansolo/tilesfx/Demo.java
+++ b/src/main/java/eu/hansolo/tilesfx/Demo.java
@@ -42,6 +42,7 @@ import javafx.animation.AnimationTimer;
 import javafx.application.Application;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -51,6 +52,8 @@ import javafx.scene.PerspectiveCamera;
 import javafx.scene.Scene;
 import javafx.scene.chart.XYChart;
 import javafx.scene.control.Button;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.image.Image;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
@@ -153,6 +156,7 @@ public class Demo extends Application {
     private Tile            timelineTile;
     private Tile            imageCounterTile;
     private Tile            ledTile;
+    private Tile            tableTile;
 
 
     private long            lastTimerCall;
@@ -837,6 +841,38 @@ public class Demo extends Application {
                 .text("Whatever text")
                 .build();
 
+        // setup table tile
+        TableColumn<String, Person> column1 = new TableColumn<>("First name");
+        column1.setCellValueFactory(new PropertyValueFactory<>("firstName"));
+        TableColumn<String, Person> column2 = new TableColumn<>("Last name");
+        column2.setCellValueFactory(new PropertyValueFactory<>("lastName"));
+        TableColumn<String, Person> column3 = new TableColumn<>("Birth place");
+        column3.setCellValueFactory(new PropertyValueFactory<>("birthPlace"));
+        TableColumn<Integer, Person> column4 = new TableColumn<>("Age");
+        column4.setCellValueFactory(new PropertyValueFactory<>("age"));
+//        TableColumn<Integer, Person> column5 = new TableColumn<>("Age");
+//        column5.setCellValueFactory(new PropertyValueFactory<>("age"));
+//        TableColumn<Integer, Person> column6 = new TableColumn<>("Loooooong");
+//        column6.setCellValueFactory(new PropertyValueFactory<>("age"));
+
+        Person a = new Person("Long", "Johnson", "Angera", 26);
+        Person b = new Person("Mike", "Funkyman", "Varese", 28);
+        Person c = new Person("Scott", "Tuner", "Bologna", 37);
+        Person d = new Person("Bryce", "Mice", "Comabbio", 47);
+        Person aa = new Person("Duke", "Lemover", "Angera", 26);
+        Person bb = new Person("Jason", "Moveon", "Varese", 28);
+        Person cc = new Person("Why", "Notsure", "Bologna", 37);
+        Person dd = new Person("Whatever", "Whatever", "Comabbio", 47);
+
+        tableTile = TileBuilder.create()
+                .skinType(SkinType.TABLE)
+                .prefSize(300, 200)
+                .title("Table Tile")
+                .insetsEnabled(false)
+                .tableColumns(column1, column2, column3, column4)
+                .tableItems(FXCollections.observableArrayList(a, b, c, d, aa, bb, cc, dd))
+                .build();
+
         lastTimerCall = System.nanoTime();
         timer = new AnimationTimer() {
             @Override public void handle(long now) {
@@ -921,7 +957,7 @@ public class Demo extends Application {
                                              smoothAreaChartTile, countryTile, ephemerisTile, characterTile,
                                              flipTile, switchSliderTile, dateTile, calendarTile, sunburstTile,
                                              matrixTile, radialPercentageTile, statusTile, barGaugeTile, imageTile,
-                                             timelineTile, imageCounterTile, ledTile);//, weatherTile);
+                                             timelineTile, imageCounterTile, ledTile, tableTile);//, weatherTile);
 
         pane.setHgap(5);
         pane.setVgap(5);
@@ -981,5 +1017,34 @@ public class Demo extends Application {
 
     public static void main(String[] args) {
         launch(args);
+    }
+
+
+    public class Person {
+        public String firstName;
+        public String lastName;
+        public String birthPlace;
+        public Integer age;
+
+
+        public Person(String firstName, String lastName, String birthPlace, Integer age) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.birthPlace = birthPlace;
+            this.age = age;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+        public String getLastName() {
+            return lastName;
+        }
+        public String getBirthPlace() {
+            return birthPlace;
+        }
+        public Integer getAge() {
+            return age;
+        }
     }
 }

--- a/src/main/java/eu/hansolo/tilesfx/Tile.java
+++ b/src/main/java/eu/hansolo/tilesfx/Tile.java
@@ -564,8 +564,8 @@ public class Tile extends Control {
     private EventHandler<MouseEvent>       infoRegionHandler;
     private boolean                        _insetsEnabled;
     private BooleanProperty                insetsEnabled;
-    private boolean                        _contentCentered;
-    private BooleanProperty                contentCentered;
+    private boolean _contentFill;
+    private BooleanProperty contentFill;
     private TableColumn<?, ?>[]            _tableColumns;
     private ObjectProperty<TableColumn<?, ?>[]> tableColumns;
     private ObservableList<?>               _tableItems;
@@ -5606,14 +5606,14 @@ public class Tile extends Control {
         return insetsEnabled;
     }
 
-    public boolean isContentCentered() { return null == contentCentered ? _contentCentered : contentCentered.get(); }
+    public boolean isContentFill() { return null == contentFill ? _contentFill : contentFill.get(); }
 
-    public void setContentCentered(final boolean CONTENT_CENTERED) {
-        if (null == contentCentered) { _contentCentered = CONTENT_CENTERED; } else { contentCentered.set(CONTENT_CENTERED); }
+    public void setContentFill(final boolean CONTENT_CENTERED) {
+        if (null == contentFill) { _contentFill = CONTENT_CENTERED; } else { contentFill.set(CONTENT_CENTERED); }
     }
-    public BooleanProperty contentCenteredProperty() {
-        if (null == contentCentered) { contentCentered = new SimpleBooleanProperty(Tile.this, "contentCentered", _contentCentered); }
-        return contentCentered;
+    public BooleanProperty contentFillProperty() {
+        if (null == contentFill) { contentFill = new SimpleBooleanProperty(Tile.this, "contentFill", _contentFill); }
+        return contentFill;
     }
 
     public TableColumn<?, ?>[] getTableColumns () { return null == tableColumns ? _tableColumns : tableColumns.get(); }

--- a/src/main/java/eu/hansolo/tilesfx/Tile.java
+++ b/src/main/java/eu/hansolo/tilesfx/Tile.java
@@ -50,22 +50,7 @@ import javafx.application.Platform;
 import javafx.beans.NamedArg;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.BooleanPropertyBase;
-import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.DoublePropertyBase;
-import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.IntegerPropertyBase;
-import javafx.beans.property.LongProperty;
-import javafx.beans.property.LongPropertyBase;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ObjectPropertyBase;
-import javafx.beans.property.ReadOnlyDoubleProperty;
-import javafx.beans.property.ReadOnlyLongProperty;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleDoubleProperty;
-import javafx.beans.property.StringProperty;
-import javafx.beans.property.StringPropertyBase;
+import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
@@ -79,6 +64,7 @@ import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart.Series;
 import javafx.scene.control.Control;
 import javafx.scene.control.Skin;
+import javafx.scene.control.TableColumn;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.input.MouseEvent;
@@ -141,7 +127,7 @@ public class Tile extends Control {
                            STATUS("StatusTileSkin"), BAR_GAUGE("BarGaugeTileSkin"),
                            IMAGE("ImageTileSkin"), IMAGE_COUNTER("ImageCounterTileSkin"),
                            TIMELINE("TimelineTileSkin"), CLUSTER_MONITOR("ClusterMonitorTileSkin"),
-                           LED("LedTileSkin");
+                           LED("LedTileSkin"), TABLE("TableTileSkin");
 
         public final String CLASS_NAME;
         SkinType(final String CLASS_NAME) {
@@ -576,6 +562,14 @@ public class Tile extends Control {
     private int                            _numberOfValuesForTrendCalculation;
     private IntegerProperty                numberOfValuesForTrendCalculation;
     private EventHandler<MouseEvent>       infoRegionHandler;
+    private boolean                        _insetsEnabled;
+    private BooleanProperty                insetsEnabled;
+    private boolean                        _contentCentered;
+    private BooleanProperty                contentCentered;
+    private TableColumn<?, ?>[]            _tableColumns;
+    private ObjectProperty<TableColumn<?, ?>[]> tableColumns;
+    private ObservableList<?>               _tableItems;
+    private ObjectProperty<ObservableList<?>> tableItems;
 
     private volatile ScheduledFuture<?>       periodicTickTask;
     private          ScheduledExecutorService periodicTickExecutorService;
@@ -5602,6 +5596,48 @@ public class Tile extends Control {
         fireTileEvent(INFO_REGION_HANDLER_EVENT);
     }
 
+    public boolean areInsetsEnabled() { return null == insetsEnabled ? _insetsEnabled : insetsEnabled.get(); }
+
+    public void setInsetsEnabled(final boolean INSETS_ENABLED) {
+        if (null == insetsEnabled) { _insetsEnabled = INSETS_ENABLED; } else { insetsEnabled.set(INSETS_ENABLED); }
+    }
+    public BooleanProperty insetsEnabledProperty() {
+        if (null == insetsEnabled) { insetsEnabled = new SimpleBooleanProperty(Tile.this, "insetsEnabled", _insetsEnabled); }
+        return insetsEnabled;
+    }
+
+    public boolean isContentCentered() { return null == contentCentered ? _contentCentered : contentCentered.get(); }
+
+    public void setContentCentered(final boolean CONTENT_CENTERED) {
+        if (null == contentCentered) { _contentCentered = CONTENT_CENTERED; } else { contentCentered.set(CONTENT_CENTERED); }
+    }
+    public BooleanProperty contentCenteredProperty() {
+        if (null == contentCentered) { contentCentered = new SimpleBooleanProperty(Tile.this, "contentCentered", _contentCentered); }
+        return contentCentered;
+    }
+
+    public TableColumn<?, ?>[] getTableColumns () { return null == tableColumns ? _tableColumns : tableColumns.get(); }
+
+    public void setTableColumns (final TableColumn<?, ?>[] TABLE_COLUMNS) {
+        if (null == tableColumns) { _tableColumns = TABLE_COLUMNS; } else { tableColumns.set(TABLE_COLUMNS); }
+    }
+
+    public ObjectProperty<TableColumn<?, ?>[]> tableColumnProperty() {
+        if (null == tableColumns) { tableColumns = new SimpleObjectProperty<>(Tile.this, "tableColumns", _tableColumns); }
+        return tableColumns;
+    }
+
+    public ObservableList<?> getTableItems () { return null == tableItems ? _tableItems : tableItems.get(); }
+
+    public void setTableItems (final ObservableList<?> TABLE_ITEMS) {
+        if (null == tableItems) { _tableItems = TABLE_ITEMS; } else { tableItems.set(TABLE_ITEMS); }
+    }
+
+    public ObjectProperty<ObservableList<?>> tableItemsProperty () {
+        if (null == tableItems) { tableItems = new SimpleObjectProperty<>(Tile.this, "tableItems", _tableItems); }
+        return tableItems;
+    }
+
     public boolean isShowing() { return null == showing ? false : showing.get(); }
     public BooleanBinding showingProperty() { return showing; }
 
@@ -5853,6 +5889,7 @@ public class Tile extends Control {
             case TIMELINE         : return new TimelineTileSkin(Tile.this);
             case CLUSTER_MONITOR  : return new ClusterMonitorTileSkin(Tile.this);
             case LED              : return new LedTileSkin(Tile.this);
+            case TABLE            : return new TableTileSkin(Tile.this);
             default               : return new TileSkin(Tile.this);
         }
     }
@@ -6020,6 +6057,8 @@ public class Tile extends Control {
                 break;
             case LED:
                 break;
+            case TABLE:
+                break;
             default:
                 break;
         }
@@ -6072,6 +6111,7 @@ public class Tile extends Control {
             case TIMELINE         : setSkin(new TimelineTileSkin(Tile.this)); break;
             case CLUSTER_MONITOR  : setSkin(new ClusterMonitorTileSkin(Tile.this)); break;
             case LED              : setSkin(new LedTileSkin(Tile.this)); break;
+            case TABLE            : setSkin((new TableTileSkin(Tile.this))); break;
             default               : setSkin(new TileSkin(Tile.this)); break;
         }
         fireTileEvent(RESIZE_EVENT);

--- a/src/main/java/eu/hansolo/tilesfx/Tile.java
+++ b/src/main/java/eu/hansolo/tilesfx/Tile.java
@@ -140,7 +140,8 @@ public class Tile extends Control {
                            RADIAL_PERCENTAGE("RadialPercentageTileSkin"),
                            STATUS("StatusTileSkin"), BAR_GAUGE("BarGaugeTileSkin"),
                            IMAGE("ImageTileSkin"), IMAGE_COUNTER("ImageCounterTileSkin"),
-                           TIMELINE("TimelineTileSkin"), CLUSTER_MONITOR("ClusterMonitorTileSkin");
+                           TIMELINE("TimelineTileSkin"), CLUSTER_MONITOR("ClusterMonitorTileSkin"),
+                           LED("LedTileSkin");
 
         public final String CLASS_NAME;
         SkinType(final String CLASS_NAME) {
@@ -2578,7 +2579,7 @@ public class Tile extends Control {
         }
         return foregroundColor;
     }
-    
+
     /**
      * Returns the Paint object that will be used to fill the tile background.
      * This is usally a Color object.
@@ -2992,7 +2993,7 @@ public class Tile extends Control {
         }
         return shadowsEnabled;
     }
-    
+
     public Locale getLocale() { return null == locale ? _locale : locale.get(); }
     public void setLocale(final Locale LOCALE) {
         if (null == locale) {
@@ -3128,7 +3129,7 @@ public class Tile extends Control {
         }
         return tickLabelDecimals;
     }
-    
+
     /**
      * Returns the color that will be used to colorize the needle of
      * the radial tiles.
@@ -3767,7 +3768,7 @@ public class Tile extends Control {
         }
         return highlightSections;
     }
-    
+
     /**
      * Returns the orientation of the control. This feature
      * will only be used in the BulletChartSkin and LinearSkin.
@@ -3802,7 +3803,7 @@ public class Tile extends Control {
         }
         return orientation;
     }
-    
+
     /**
      * Returns true if the control should keep it's aspect. This is
      * in principle only needed if the control has different width and
@@ -3994,7 +3995,7 @@ public class Tile extends Control {
         return zoneId;
     }
 
-    
+
     /**
      * Returns the text that was defined for the clock.
      * This text could be used for additional information.
@@ -4121,7 +4122,7 @@ public class Tile extends Control {
         getTimeSections().clear();
         fireTileEvent(SECTION_EVENT);
     }
-    
+
     /**
      * Returns true if the second hand of the clock should move
      * in discrete steps of 1 second. Otherwise it will move continuously like
@@ -4535,7 +4536,7 @@ public class Tile extends Control {
         }
         return tickMarkColor;
     }
-    
+
     /**
      * Returns true if the hour tickmarks will be drawn.
      * @return true if the hour tickmarks will be drawn
@@ -5291,12 +5292,12 @@ public class Tile extends Control {
         _notifyRegionForegroundColor = COLOR;
         fireTileEvent(REDRAW_EVENT);
     }
-    
+
     public String getNotifyRegionTooltipText() { return _notifyRegionTooltipText; }
     public void setNotifyRegionTooltipText(final String TEXT) {
         _notifyRegionTooltipText = TEXT;
         fireTileEvent(REDRAW_EVENT);
-    }    
+    }
 
     public Color getInfoRegionBackgroundColor() { return _infoRegionBackgroundColor; }
     public void setInfoRegionBackgroundColor(final Color COLOR) {
@@ -5397,7 +5398,7 @@ public class Tile extends Control {
         }
         return rightText;
     }
-    
+
     public double getLeftValue() { return null == leftValue ? _leftValue : leftValue.get(); }
     public void setLeftValue(final double VALUE) {
         if (null == leftValue) {
@@ -5457,7 +5458,7 @@ public class Tile extends Control {
         }
         return rightValue;
     }
-    
+
     public Node getLeftGraphics() { return null == leftGraphics ? _leftGraphics : leftGraphics.get(); }
     public void setLeftGraphics(final Node NODE) {
         if (null == leftGraphics) {
@@ -5741,7 +5742,7 @@ public class Tile extends Control {
 
     private void createShutdownHook() { Runtime.getRuntime().addShutdownHook(new Thread(() -> stop())); }
 
-    
+
     // ******************** Event handling ************************************
     public void setOnTileEvent(final TileEventListener LISTENER) { addTileEventListener(LISTENER); }
     public void addTileEventListener(final TileEventListener LISTENER) { if (!tileEventListeners.contains(LISTENER)) tileEventListeners.add(LISTENER); }
@@ -5756,7 +5757,7 @@ public class Tile extends Control {
         }
     }
 
-    
+
     public void setOnAlarm(final AlarmEventListener LISTENER) { addAlarmEventListener(LISTENER); }
     public void addAlarmEventListener(final AlarmEventListener LISTENER) { if (!alarmEventListeners.contains(LISTENER)) alarmEventListeners.add(LISTENER); }
     public void removeAlarmEventListener(final AlarmEventListener LISTENER) { if (alarmEventListeners.contains(LISTENER)) alarmEventListeners.remove(LISTENER); }
@@ -5789,9 +5790,9 @@ public class Tile extends Control {
                 return getScene().getWindow().isShowing();
             } else {
                 return false;
-            }            
+            }
         }, sceneProperty(), getScene().windowProperty(), getScene().getWindow().showingProperty());
-        
+
         showing.addListener(o -> {
         if (showing.get()) {
             while(tileEventQueue.peek() != null) {
@@ -5851,6 +5852,7 @@ public class Tile extends Control {
             case IMAGE_COUNTER    : return new ImageCounterTileSkin(Tile.this);
             case TIMELINE         : return new TimelineTileSkin(Tile.this);
             case CLUSTER_MONITOR  : return new ClusterMonitorTileSkin(Tile.this);
+            case LED              : return new LedTileSkin(Tile.this);
             default               : return new TileSkin(Tile.this);
         }
     }
@@ -6016,6 +6018,8 @@ public class Tile extends Control {
                 setDecimals(0);
                 setBarColor(BLUE);
                 break;
+            case LED:
+                break;
             default:
                 break;
         }
@@ -6067,6 +6071,7 @@ public class Tile extends Control {
             case IMAGE_COUNTER    : setSkin(new ImageCounterTileSkin(Tile.this)); break;
             case TIMELINE         : setSkin(new TimelineTileSkin(Tile.this)); break;
             case CLUSTER_MONITOR  : setSkin(new ClusterMonitorTileSkin(Tile.this)); break;
+            case LED              : setSkin(new LedTileSkin(Tile.this)); break;
             default               : setSkin(new TileSkin(Tile.this)); break;
         }
         fireTileEvent(RESIZE_EVENT);

--- a/src/main/java/eu/hansolo/tilesfx/TileBuilder.java
+++ b/src/main/java/eu/hansolo/tilesfx/TileBuilder.java
@@ -52,6 +52,7 @@ import javafx.beans.property.SimpleLongProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.geometry.Dimension2D;
 import javafx.geometry.Insets;
@@ -60,6 +61,7 @@ import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.chart.Axis;
 import javafx.scene.chart.XYChart.Series;
+import javafx.scene.control.TableColumn;
 import javafx.scene.image.Image;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.paint.Color;
@@ -1105,6 +1107,26 @@ public class TileBuilder<B extends TileBuilder<B>> {
         return (B)this;
     }
 
+    public final B insetsEnabled(final boolean INSETS_ENABLED) {
+        properties.put("insetsEnabled", new SimpleBooleanProperty(INSETS_ENABLED));
+        return (B)this;
+    }
+
+    public final B contentCentered(final boolean CONTENT_CENTERED) {
+        properties.put("contentCentered", new SimpleBooleanProperty(CONTENT_CENTERED));
+        return (B)this;
+    }
+
+    public final B tableColumns(final TableColumn<?, ?>... COLUMNS) {
+        properties.put("tableColumns", new SimpleObjectProperty(COLUMNS));
+        return (B)this;
+    }
+
+    public final B tableItems(final ObservableList<?> ITEMS) {
+        properties.put("tableItems", new SimpleObjectProperty(ITEMS));
+        return (B)this;
+    }
+
 
     public final Tile build() {
         final Tile TILE;
@@ -1399,6 +1421,10 @@ public class TileBuilder<B extends TileBuilder<B>> {
                 TILE.setTranslateX(((DoubleProperty) properties.get(key)).get());
             } else if ("translateY".equals(key)) {
                 TILE.setTranslateY(((DoubleProperty) properties.get(key)).get());
+            } else if ("insetsEnabled".equals(key)) {
+                TILE.setInsetsEnabled(((BooleanProperty) properties.get(key)).get());
+            } else if ("contentCentered".equals(key)) {
+                TILE.setContentCentered(((BooleanProperty) properties.get(key)).get());
             } else if ("padding".equals(key)) {
                 TILE.setPadding(((ObjectProperty<Insets>) properties.get(key)).get());
             } else if("styleClass".equals(key)) {
@@ -1726,7 +1752,11 @@ public class TileBuilder<B extends TileBuilder<B>> {
                 TILE.setInfoRegionTooltipText(((StringProperty) properties.get(key)).get());
             } else if ("notifyRegionTooltipText".equals(key)) {
                 TILE.setNotifyRegionTooltipText(((StringProperty) properties.get(key)).get());
-            } 
+            } else if ("tableColumns".equals(key)) {
+                TILE.setTableColumns(((ObjectProperty<TableColumn<?, ?>[]>) properties.get(key)).get());
+            } else if ("tableItems".equals(key)) {
+                TILE.setTableItems(((ObjectProperty<ObservableList<?>>) properties.get(key)).get());
+            }
         }
         properties.clear();
         return TILE;

--- a/src/main/java/eu/hansolo/tilesfx/TileBuilder.java
+++ b/src/main/java/eu/hansolo/tilesfx/TileBuilder.java
@@ -1424,7 +1424,7 @@ public class TileBuilder<B extends TileBuilder<B>> {
             } else if ("insetsEnabled".equals(key)) {
                 TILE.setInsetsEnabled(((BooleanProperty) properties.get(key)).get());
             } else if ("contentCentered".equals(key)) {
-                TILE.setContentCentered(((BooleanProperty) properties.get(key)).get());
+                TILE.setContentFill(((BooleanProperty) properties.get(key)).get());
             } else if ("padding".equals(key)) {
                 TILE.setPadding(((ObjectProperty<Insets>) properties.get(key)).get());
             } else if("styleClass".equals(key)) {

--- a/src/main/java/eu/hansolo/tilesfx/skins/LedTileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/LedTileSkin.java
@@ -1,0 +1,163 @@
+package eu.hansolo.tilesfx.skins;
+
+import eu.hansolo.tilesfx.Tile;
+import eu.hansolo.tilesfx.fonts.Fonts;
+import eu.hansolo.tilesfx.tools.Helper;
+import javafx.scene.control.Label;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.CycleMethod;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Stop;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Ellipse;
+import javafx.scene.text.Font;
+import javafx.scene.text.Text;
+
+import static eu.hansolo.tilesfx.tools.Helper.clamp;
+
+@SuppressWarnings("Duplicates")
+public class LedTileSkin extends TileSkin {
+    private static final Color BORDER_COLOR = new Color(0.8, 0.8, 0.8, 1);
+    private static final Color OFF_COLOR = new Color(0.4, 0.5, 0.5, 1);
+    private static final Color ON_DEFAULT_COLOR = new Color (0.88, 0.18, 0.05, 1);
+    private Text titleText;
+    private Text text;
+    private Label description;
+    private Circle ledBorder;
+    private Circle led;
+    private Ellipse glassEffect;
+
+
+    // ******************** Constructors **************************************
+    public LedTileSkin(final Tile TILE) {
+        super(TILE);
+    }
+
+
+    // ******************** Initialization ************************************
+    @Override protected void initGraphics() {
+        super.initGraphics();
+
+        titleText = new Text();
+        titleText.setFill(tile.getTitleColor());
+        Helper.enableNode(titleText, !tile.getTitle().isEmpty());
+
+        text = new Text(tile.getText());
+        text.setFill(tile.getUnitColor());
+        Helper.enableNode(text, tile.isTextVisible());
+
+        description = new Label(tile.getDescription());
+        description.setAlignment(tile.getDescriptionAlignment());
+        description.setWrapText(true);
+        description.setTextFill(tile.getTextColor());
+        Helper.enableNode(description, !tile.getDescription().isEmpty());
+
+        ledBorder = new Circle();
+        led = new Circle();
+        glassEffect = new Ellipse();
+
+        getPane().getChildren().addAll(titleText, text, description, ledBorder, led, glassEffect);
+    }
+
+
+    // ******************** Methods *******************************************
+    @Override protected void handleEvents(final String EVENT_TYPE) {
+        super.handleEvents(EVENT_TYPE);
+
+        if ("VISIBILITY".equals(EVENT_TYPE)) {
+            Helper.enableNode(titleText, !tile.getTitle().isEmpty());
+            Helper.enableNode(text, tile.isTextVisible());
+            Helper.enableNode(description, !tile.getDescription().isEmpty());
+        }
+    }
+
+    @Override protected void handleCurrentValue(final double VALUE) {
+        updateLedStatus();
+    }
+
+    private void updateLedStatus () {
+        if (tile.getValue() == 0) {
+            led.setFill(OFF_COLOR);
+        }
+        else {
+            led.setFill(tile.getActiveColor() == null ? ON_DEFAULT_COLOR : tile.getActiveColor());
+        }
+    }
+
+
+    // ******************** Resizing ******************************************
+    @Override protected void resizeStaticText() {
+        double maxWidth = width - size * 0.1;
+        double fontSize = size * textSize.factor;
+
+        boolean customFontEnabled = tile.isCustomFontEnabled();
+        Font customFont        = tile.getCustomFont();
+        Font font              = (customFontEnabled && customFont != null) ? Font.font(customFont.getFamily(), fontSize) : Fonts.latoRegular(fontSize);
+
+        titleText.setFont(font);
+        if (titleText.getLayoutBounds().getWidth() > maxWidth) { Helper.adjustTextSize(titleText, maxWidth, fontSize); }
+        switch(tile.getTitleAlignment()) {
+            default    :
+            case LEFT  : titleText.relocate(size * 0.05, size * 0.05); break;
+            case CENTER: titleText.relocate((width - titleText.getLayoutBounds().getWidth()) * 0.5, size * 0.05); break;
+            case RIGHT : titleText.relocate(width - (size * 0.05) - titleText.getLayoutBounds().getWidth(), size * 0.05); break;
+        }
+
+        text.setText(tile.getText());
+        text.setFont(font);
+        if (text.getLayoutBounds().getWidth() > maxWidth) { Helper.adjustTextSize(text, maxWidth, fontSize); }
+        switch(tile.getTextAlignment()) {
+            default    :
+            case LEFT  : text.setX(size * 0.05); break;
+            case CENTER: text.setX((width - text.getLayoutBounds().getWidth()) * 0.5); break;
+            case RIGHT : text.setX(width - (size * 0.05) - text.getLayoutBounds().getWidth()); break;
+        }
+        text.setY(height - size * 0.05);
+
+        fontSize = size * 0.1;
+        description.setFont(Fonts.latoRegular(fontSize));
+    }
+
+    @Override protected void resize() {
+        super.resize();
+
+        description.setPrefSize(contentBounds.getWidth(), size * 0.43);
+        description.relocate(contentBounds.getX(), height * 0.42);
+
+        double diameter = ledBorder.getRadius() * 2;
+        double borderWidth = diameter / 11;
+        ledBorder.setRadius(size / 7);
+        ledBorder.setStrokeWidth(borderWidth);
+        ledBorder.relocate((width - diameter - borderWidth) * 0.5, tile.getDescription().isEmpty() ? (height - diameter - borderWidth) * 0.5 : height - size * 0.40);
+
+        led.setRadius(size / 8.8);
+        diameter = led.getRadius() * 2;
+        led.relocate((width - diameter) * 0.5, tile.getDescription().isEmpty() ? (height - diameter) * 0.5 : height - size * 0.39);
+
+        glassEffect.setRadiusX(diameter / 2.2);
+        glassEffect.setRadiusY(diameter / 3.7);
+        glassEffect.relocate((width - (glassEffect.getRadiusX() * 2)) * 0.5, ((height - (glassEffect.getRadiusY() * 2)) / 2) - (diameter / 5));
+    }
+
+
+    @Override protected void redraw() {
+        super.redraw();
+
+        titleText.setText(tile.getTitle());
+        text.setText(tile.getText());
+        description.setText(tile.getDescription());
+        description.setAlignment(tile.getDescriptionAlignment());
+
+        resizeStaticText();
+
+        titleText.setFill(tile.getTitleColor());
+        text.setFill(tile.getTextColor());
+        description.setTextFill(tile.getDescriptionColor());
+        ledBorder.setStroke(BORDER_COLOR);
+        updateLedStatus();
+
+        Stop[] stops = new Stop[] { new Stop(0, new Color(1, 1, 1, 0.5)), new Stop(1, new Color(1, 1, 1, 0.05))};
+        LinearGradient glassGradient = new LinearGradient(0, 0, 0, 1, true, CycleMethod.NO_CYCLE, stops);
+        glassEffect.setFill(glassGradient);
+    }
+}

--- a/src/main/java/eu/hansolo/tilesfx/skins/LedTileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/LedTileSkin.java
@@ -124,9 +124,9 @@ public class LedTileSkin extends TileSkin {
         description.setPrefSize(contentBounds.getWidth(), size * 0.43);
         description.relocate(contentBounds.getX(), height * 0.42);
 
-        double diameter = ledBorder.getRadius() * 2;
+        double diameter = size / 7 * 2;
         double borderWidth = diameter / 11;
-        ledBorder.setRadius(size / 7);
+        ledBorder.setRadius(diameter / 2);
         ledBorder.setStrokeWidth(borderWidth);
         ledBorder.relocate((width - diameter - borderWidth) * 0.5, tile.getDescription().isEmpty() ? (height - diameter - borderWidth) * 0.5 : height - size * 0.40);
 
@@ -134,8 +134,8 @@ public class LedTileSkin extends TileSkin {
         diameter = led.getRadius() * 2;
         led.relocate((width - diameter) * 0.5, tile.getDescription().isEmpty() ? (height - diameter) * 0.5 : height - size * 0.39);
 
-        glassEffect.setRadiusX(diameter / 2.2);
-        glassEffect.setRadiusY(diameter / 3.7);
+        glassEffect.setRadiusX(diameter / 2.6);
+        glassEffect.setRadiusY(diameter / 3.5);
         glassEffect.relocate((width - (glassEffect.getRadiusX() * 2)) * 0.5, ((height - (glassEffect.getRadiusY() * 2)) / 2) - (diameter / 5));
     }
 
@@ -154,6 +154,7 @@ public class LedTileSkin extends TileSkin {
         text.setFill(tile.getTextColor());
         description.setTextFill(tile.getDescriptionColor());
         ledBorder.setStroke(BORDER_COLOR);
+        ledBorder.setFill(Color.TRANSPARENT);
         updateLedStatus();
 
         Stop[] stops = new Stop[] { new Stop(0, new Color(1, 1, 1, 0.5)), new Stop(1, new Color(1, 1, 1, 0.05))};

--- a/src/main/java/eu/hansolo/tilesfx/skins/SmoothAreaChartTileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/SmoothAreaChartTileSkin.java
@@ -275,6 +275,8 @@ public class SmoothAreaChartTileSkin extends TileSkin {
         if (POINTS.isEmpty()) return;
         Point[] points = smoothing ? Helper.subdividePoints(POINTS.toArray(new Point[0]), 8) : POINTS.toArray(new Point[0]);
 
+        if (points.length == 0 || points[0] == null) return;
+
         fillPath.getElements().clear();
         fillPath.getElements().add(new MoveTo(0, height));
 

--- a/src/main/java/eu/hansolo/tilesfx/skins/TableTileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/TableTileSkin.java
@@ -1,0 +1,82 @@
+package eu.hansolo.tilesfx.skins;
+
+import eu.hansolo.tilesfx.Tile;
+import eu.hansolo.tilesfx.fonts.Fonts;
+import eu.hansolo.tilesfx.tools.Helper;
+import javafx.scene.control.TableView;
+import javafx.scene.text.Font;
+import javafx.scene.text.Text;
+
+import java.util.Arrays;
+
+public class TableTileSkin extends TileSkin {
+
+    private Text           titleText;
+    private TableView      tableView;
+
+
+    public TableTileSkin(Tile TILE) {
+        super(TILE);
+
+        titleText = new Text();
+        titleText.setFill(tile.getTitleColor());
+        Helper.enableNode(titleText, !tile.getTitle().isEmpty());
+
+        tableView = new TableView();
+        tableView.setId("tableTile");
+        tableView.getColumns().addAll(Arrays.asList(tile.getTableColumns()));
+        tableView.setItems(tile.getTableItems());
+
+        getPane().getChildren().addAll(titleText, tableView);
+    }
+
+
+    // ******************** Methods *******************************************
+    @Override protected void handleEvents(final String EVENT_TYPE) {
+        super.handleEvents(EVENT_TYPE);
+
+        if ("VISIBILITY".equals(EVENT_TYPE)) {
+            Helper.enableNode(titleText, !tile.getTitle().isEmpty());
+        }
+    }
+
+
+    // ******************** Resizing ******************************************
+    @Override protected void resizeStaticText() {
+        double maxWidth = width - size * 0.1;
+        double fontSize = Math.min(size * textSize.factor, 20);
+        double y = Math.min(15, size * 0.05);
+
+        boolean customFontEnabled = tile.isCustomFontEnabled();
+        Font customFont        = tile.getCustomFont();
+        Font font              = (customFontEnabled && customFont != null) ? Font.font(customFont.getFamily(), fontSize) : Fonts.latoRegular(fontSize);
+
+        titleText.setFont(font);
+        if (titleText.getLayoutBounds().getWidth() > maxWidth) { Helper.adjustTextSize(titleText, maxWidth, fontSize); }
+        switch(tile.getTitleAlignment()) {
+            default    :
+            case LEFT  : titleText.relocate(size * 0.05, y); break;
+            case CENTER: titleText.relocate((width - titleText.getLayoutBounds().getWidth()) * 0.5, y); break;
+            case RIGHT : titleText.relocate(width - (size * 0.05) - titleText.getLayoutBounds().getWidth(), y); break;
+        }
+    }
+
+
+    @Override protected void resize() {
+        super.resize();
+
+        double topOffset = Math.min(tile.getHeight() * 0.15, 50);
+        tableView.setPrefWidth(tile.getWidth());
+        tableView.setPrefHeight(tile.getHeight() - topOffset);
+        tableView.relocate(0, topOffset);
+    }
+
+
+    @Override protected void redraw() {
+        super.redraw();
+
+        titleText.setText(tile.getTitle());
+        resizeStaticText();
+        titleText.setFill(tile.getTitleColor());
+    }
+}

--- a/src/main/java/eu/hansolo/tilesfx/skins/TileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/TileSkin.java
@@ -256,15 +256,15 @@ public class TileSkin extends SkinBase<Tile> implements Skin<Tile> {
         stepSize = width / range;
         shadow.setRadius(size * 0.012);
 
-        inset       = size * 0.05;
+        inset       = (tile.areInsetsEnabled() ? size * 0.05 : 0);
         doubleInset = inset * 2;
 
         if (tile.isShowing() && width > 0 && height > 0) {
             //pane.setMaxSize(size, size);
             //pane.relocate((width - size) * 0.5, (height - size) * 0.5);
 
-            double offsetTop    = tile.getTitle().isEmpty() ? inset : size * 0.15;
-            double offsetBottom = tile.getText().isEmpty() ? height - inset : height - size * 0.15;
+            double offsetTop    = (tile.isContentCentered() ? 0 : (tile.getTitle().isEmpty() ? inset : size * 0.15));
+            double offsetBottom = (tile.isContentCentered() ? height : (tile.isTextVisible() ? height - size * 0.15 : height - inset));
             contentBounds.setX(inset);
             contentBounds.setY(offsetTop);
             contentBounds.setWidth(width - doubleInset);

--- a/src/main/java/eu/hansolo/tilesfx/skins/TileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/TileSkin.java
@@ -263,8 +263,8 @@ public class TileSkin extends SkinBase<Tile> implements Skin<Tile> {
             //pane.setMaxSize(size, size);
             //pane.relocate((width - size) * 0.5, (height - size) * 0.5);
 
-            double offsetTop    = (tile.isContentCentered() ? 0 : (tile.getTitle().isEmpty() ? inset : size * 0.15));
-            double offsetBottom = (tile.isContentCentered() ? height : (tile.isTextVisible() ? height - size * 0.15 : height - inset));
+            double offsetTop    = (tile.isContentFill() ? 0 : (tile.getTitle().isEmpty() ? inset : size * 0.15));
+            double offsetBottom = (tile.isContentFill() ? height : (tile.isTextVisible() ? height - size * 0.15 : height - inset));
             contentBounds.setX(inset);
             contentBounds.setY(offsetTop);
             contentBounds.setWidth(width - doubleInset);

--- a/src/main/resources/eu/hansolo/tilesfx/tilesfx.css
+++ b/src/main/resources/eu/hansolo/tilesfx/tilesfx.css
@@ -269,3 +269,113 @@
     -fx-background-color: -symbol-color;
     -fx-shape: "M 43.3719 33.1445 C 43.3719 25.9672 37.5511 20.1499 30.3707 20.1499 C 23.1904 20.1499 17.3696 25.9672 17.3696 33.1445 C 4.3684 33.1445 4.3684 33.1503 4.3684 33.1503 L 4.3684 35.1497 L 26.3704 35.1497 L 26.3704 33.1503 L 19.3698 33.1503 C 19.3698 27.088 24.3048 22.1492 30.3707 22.1492 C 36.4367 22.1492 41.3717 27.0821 41.3717 33.1445 C 34.3711 33.1445 34.3711 33.1503 34.3711 33.1503 L 34.3711 35.1497 L 56.3682 35.1497 L 56.3682 33.1503 L 43.3719 33.1445 ZM 31.364 41.6953 L 31.364 31.152 L 29.3638 31.152 L 29.3638 41.6953 L 25.1095 37.4428 L 23.6953 38.8564 L 30.3639 45.5221 L 37.0315 38.8564 L 35.6173 37.4428 L 31.364 41.6953 ZM 20.0456 21.4239 L 12.6846 14.066 L 11.2704 15.4796 L 18.6314 22.8375 L 20.0456 21.4239 ZM 49.4525 15.4747 L 48.0383 14.0612 L 40.6773 21.419 L 42.0915 22.8326 L 49.4525 15.4747 ZM 31.364 7.1602 L 29.3638 7.1602 L 29.3638 17.1567 L 31.364 17.1567 L 31.364 7.1602 Z";
 }
+
+.tile #tableTile {
+    -fx-background-color: black;
+    -fx-table-cell-border-color: transparent;
+}
+
+.tile #tableTile .label {
+    -fx-text-fill: #8b9092;
+}
+
+.tile #tableTile .column-header,
+.tile #tableTile .column-header .filler,
+.tile #tableTile .column-header-background,
+.tile #tableTile .column-header-background .filler {
+    -fx-pref-height: 20px;
+    -fx-padding: 0 0 0 5px;
+    -fx-background-color: #111;
+    -fx-border-width: 0 1px 0 0;
+    -fx-border-color: #333;
+}
+
+/*.tile #tableTile .row-header-cell {*/
+/*    -fx-background-insets: 0, 0 1 1 0, 1 2 2 1;*/
+
+/*}*/
+
+.tile #tableTile .column-header .label {
+    -fx-text-fill: #8b9092;
+    -fx-font-size: 10px;
+    -fx-font-weight: lighter;
+    -fx-alignment: center-left;
+}
+
+.tile #tableTile .table-cell {
+    -fx-text-fill: #dfdfdf;
+    -fx-font-size: 12px;
+    -fx-padding: 0 0 0 5px;
+    -fx-border-width: 0;
+}
+
+.tile #tableTile .table-row-cell {
+    -fx-background-color: #222;
+    -fx-pref-height: 24px;
+}
+
+.tile #tableTile .table-row-cell:odd {
+    -fx-background-color: transparent;
+}
+
+.tile #tableTile .table-row-cell:selected {
+    -fx-background-color: #37b3fc;
+}
+
+.tile #tableTile .table-row-cell:selected .table-cell {
+    -fx-text-fill: #333;
+    -fx-font-size: 13px;
+    -fx-background-color: #37b3fc;
+}
+
+/* The main scrollbar **track** CSS class  */
+.tile #tableTile .track-background, .tile #tableTile .corner {
+    -fx-background-color: #111;
+}
+
+.tile #tableTile .scroll-bar:horizontal .track,
+.tile #tableTile .scroll-bar:vertical .track{
+    -fx-background-color:transparent;
+    -fx-border-color:transparent;
+    -fx-background-radius: 0em;
+    -fx-border-radius:2em;
+}
+
+/* The increment and decrement button CSS class of scrollbar */
+.tile #tableTile .scroll-bar:horizontal .increment-button ,
+.tile #tableTile .scroll-bar:horizontal .decrement-button {
+    -fx-background-color:transparent;
+    -fx-background-radius: 0em;
+    -fx-padding:0 0 10 0;
+
+}
+
+/* The increment and decrement button CSS class of scrollbar */
+
+.tile #tableTile .scroll-bar:vertical .increment-button ,
+.tile #tableTile .scroll-bar:vertical .decrement-button {
+
+    -fx-background-color:transparent;
+    -fx-background-radius: 0em;
+    -fx-padding:0 10 0 0;
+
+}
+
+.tile #tableTile  .scroll-bar .increment-arrow,
+.tile #tableTile  .scroll-bar .decrement-arrow {
+    -fx-shape: " ";
+    -fx-padding:0;
+}
+
+/* The main scrollbar **thumb** CSS class which we drag every time (movable) */
+.tile #tableTile .scroll-bar:horizontal .thumb,
+.tile #tableTile .scroll-bar:vertical .thumb {
+    -fx-background-color:derive(black,90%);
+    -fx-background-insets: 2, 0, 0;
+    -fx-background-radius: 2em;
+}
+
+.tile #tableTile .scroll-bar .thumb:hover,
+.tile #tableTile .scroll-bar .thumb:pressed{
+    -fx-background-color: derive(#37b3fc, 30%);
+}


### PR DESCRIPTION
Hi HanSolo, like I mentioned yesterday I am also sending you the code for the TableTileSkin. Columns can be set via `tableColumns `property, and items via `tableItems`. 

I have also added two other properties, which are used in `TileSkin` when drawing:
- `contentFill` fills the view without taking into account top and bottom offsets (useful for example with image)
- `insetsEnabled` - if enabled, insets are 0.

I added a null check in `SmoothAreaChartTileSkin ` because it was crashing if when init the width and height of view were 0. When `drawChart` would becalled, points list would contain one element which would have NaN values, and after the `Helper.subdividePoints` it would have null items.

I decided not to pull your changes to keep the flat LED, so please bear patience with code that needs to be removed, in case you want to accept this pull request.

Cheers!
