### PR TITLE
Use existing title when Skintype added later on

### DIFF
--- a/src/main/java/eu/hansolo/tilesfx/skins/ClusterMonitorTileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/ClusterMonitorTileSkin.java
@@ -96,7 +96,7 @@ public class ClusterMonitorTileSkin extends TileSkin {
             chartPane.getChildren().add(dataItemMap.get(data));
         });
 
-        titleText = new Text();
+        titleText = new Text(tile.getTitle());
         titleText.setFill(tile.getTitleColor());
         Helper.enableNode(titleText, !tile.getTitle().isEmpty());
 


### PR DESCRIPTION
When changing the SkinType after a Tile has been created, it does not check to see if the tile has a name when initiating graphics.
This change addresses this. 

Would need to be applied to most Skins (some already do this).