### PR TITLE
Gauge2 now works with any anglerange, min, and max

### DIFF
--- a/src/main/java/eu/hansolo/tilesfx/skins/Gauge2TileSkin.java
+++ b/src/main/java/eu/hansolo/tilesfx/skins/Gauge2TileSkin.java
@@ -175,9 +175,9 @@ public class Gauge2TileSkin extends TileSkin {
         targetAngle = Helper.clamp(-needleStartAngle, -needleStartAngle + angleRange, targetAngle);
         needleRotate.setAngle(targetAngle);
         needleRectRotate.setAngle(targetAngle);
-        bar.setLength(-angleStep * VALUE);
+        bar.setLength(-angleStep * (VALUE - minValue));
         if (tile.isStrokeWithGradient()) {
-            needle.setFill(gradientLookup.getColorAt(VALUE / tile.getRange()));
+            needle.setFill(gradientLookup.getColorAt((VALUE - minValue) / tile.getRange()));
             bar.setStroke(conicalGradient.getImagePattern(barBounds));
         } else {
             needle.setFill(tile.getNeedleColor());
@@ -222,7 +222,7 @@ public class Gauge2TileSkin extends TileSkin {
         List<Stop> stops = tile.getGradientStops();
         Map<Double, Color> stopAngleMap = new HashMap<>(stops.size());
         for (Stop stop : stops) { stopAngleMap.put(stop.getOffset() * angleRange, stop.getColor()); }
-        double offsetFactor = (tile.getStartAngle() - 90);
+        double offsetFactor = ((360-angleRange)/2 + 180);
         conicalGradient = new AngleConicalGradient(barBounds.getX() * barBounds.getWidth() * 0.5, barBounds.getY() * barBounds.getHeight() * 0.5, offsetFactor, stopAngleMap);
     }
 


### PR DESCRIPTION
Currently, trying to use gauge2 with minimum values of nonzero severely impact the barlength improperly (despite the needle working fine). Additionally, angle ranges often were miscalculated when drawing the gauge fill, with a gradient stroke.

These adjustments have allowed me to create 90*, 180*, 270*, and 360* Gauge2 tiles with any minimum & maximum values.

(One request I would make, would be if you do a full 360* Gauge2 tile, that the text display of the value is dropped a bit, to be underneath the circle, rather than superimposed over it. This pull request does not have that functionality.)